### PR TITLE
[patch] fix bugsnag notify

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,10 +34,9 @@ function BugsnagLogger(options) {
 
   // expose the instance on the transport
   if (options.bugsnag) {
-    this.bugsnag = options.bugsnag;
+    this.bugsnagClient = options.bugsnag;
   } else {
-    this.bugsnag = bugsnag;
-    this.bugsnag({ apiKey: options.apiKey, ...options.config });
+    this.bugsnagClient = bugsnag({ apiKey: options.apiKey, ...options.config });
   }
 
 };
@@ -75,7 +74,7 @@ BugsnagLogger.prototype.log = function(level, msg, meta, fn) {
       msg = meta.message;
   }
 
-  this.bugsnag.notify(msg, meta, function() {
+  this.bugsnagClient.notify(msg, meta, function() {
     fn(null, true);
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "winston-bugsnag-logger",
-  "version": "0.0.1",
+  "name": "@omgaz/winston-bugsnag-logger",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "winston-bugsnag-logger",
-      "version": "0.0.1",
+      "name": "@omgaz/winston-bugsnag-logger",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "6.5.2",
@@ -36,7 +36,7 @@
         "@bugsnag/node": "^6.5.2"
       }
     },
-    "node_modules/@bugsnag/js/node_modules/@bugsnag/node": {
+    "node_modules/@bugsnag/node": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-6.5.2.tgz",
       "integrity": "sha512-KQ1twKoOttMCYsHv7OXUVsommVcrk6RGQ5YoZGlTbREhccbzsvjbiXPKiY31Qc7OXKvaJwSXhnOKrQTpRleFUg==",


### PR DESCRIPTION
Fixes ` TypeError · this.bugsnag.notify is not a function` when used in the consumer